### PR TITLE
fix: configure GitHub Pages base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,8 @@ import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 export default defineConfig({
+  // Base path for GitHub Pages deployment
+  base: "/LineageAtlas/",
   plugins: [
     react(),
     runtimeErrorOverlay(),


### PR DESCRIPTION
## Summary
- serve built assets from `/LineageAtlas/` for GitHub Pages
- document the GitHub Pages base path in Vite config

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_689bf0c961648333965c88d187e71e36