### PR TITLE
Fix GitHub Pages artifact path

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: dist/public
+          path: dist
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- fix GH Pages workflow artifact path to match Vite output

## Testing
- `npm run build`
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689bf7cae23c83338a2a29fb5b337250